### PR TITLE
added: health endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 GOPATH=$(shell go env GOPATH)
-EXEC_NAME=HTrace
 CURRENT_PATH=$(shell pwd)
 GO111MODULE=on
 IMAGE_REGISTRY=dockerhub
@@ -13,7 +12,7 @@ clean:
 	rm -f $(IMAGE_NAME).app
 
 build: clean
-	GO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o $(EXEC_NAME).app cmd/*.go
+	GO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o $(IMAGE_NAME).app cmd/*.go
 
 docker-build: build
 	docker build -t $(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(COMMIT_ID) -f ./.docker/Dockerfile .

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ that implements BlueTrace.io specification.
 $ make build
 ```
 
-this will produce an executable called `OTMock.app`
+this will produce an executable called `hypertrace.app`
 
 ## Execute
 
 ```shell
-$ OTMock.app
+$ hypertrace.app
 ```
 
 The server will run on port `8080`

--- a/handler.go
+++ b/handler.go
@@ -6,14 +6,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hyperjumptech/hypertrace/static"
-	"github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hyperjumptech/hypertrace/static"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -480,6 +481,10 @@ func generateTempId(key []byte, uid string, i uint32) (*TempID, error) {
 		StartTime:  start,
 		ExpiryTime: expiry,
 	}, err
+}
+
+func healthCheck(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func StaticMiddleware(next http.Handler) http.Handler {

--- a/handler.go
+++ b/handler.go
@@ -479,6 +479,7 @@ func generateTempId(key []byte, uid string, i uint32) (*TempID, error) {
 }
 
 func healthCheck(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("cache-control", "no-cache")
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/handler.go
+++ b/handler.go
@@ -142,7 +142,7 @@ func registerOfficer(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(fmt.Sprintf("{\"status\":\"SUCCESS\"}")))
+	w.Write([]byte("{\"status\":\"SUCCESS\"}"))
 }
 
 func deleteOfficer(w http.ResponseWriter, r *http.Request) {
@@ -170,7 +170,7 @@ func deleteOfficer(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(fmt.Sprintf("{\"status\":\"SUCCESS\"}")))
+	w.Write([]byte("{\"status\":\"SUCCESS\"}"))
 }
 
 type TempIDResponse struct {
@@ -214,7 +214,6 @@ func purgeTracing(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("{\"status\":\"SUCCESS\"}"))
-	return
 }
 
 func getTempIDs(w http.ResponseWriter, r *http.Request) {
@@ -277,7 +276,6 @@ func getUploadToken(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(fmt.Sprintf("{\"status\":\"SUCCESS\", \"token\":\"%s\"}", tok)))
-	return
 }
 
 func uploadData(w http.ResponseWriter, r *http.Request) {
@@ -421,10 +419,7 @@ type TempID struct {
 
 func (tid *TempID) IsValid(key []byte, forTime time.Time) bool {
 	_, err := decodeAndDecrypt(tid.TempID, key)
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 func GetTempIDData(key []byte, tempid string) (UID string, start, expiry int32, err error) {

--- a/server.go
+++ b/server.go
@@ -3,13 +3,14 @@ package hypertrace
 import (
 	"context"
 	"fmt"
-	mux "github.com/hyperjumptech/hyper-mux"
-	serverLog "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	mux "github.com/hyperjumptech/hyper-mux"
+	serverLog "github.com/sirupsen/logrus"
 )
 
 var (
@@ -32,6 +33,7 @@ func initRoutes() {
 	hmux.AddRoute("/uploadData", mux.MethodPost, uploadData)
 	hmux.AddRoute("/getTracing", mux.MethodGet, getTracing)
 	hmux.AddRoute("/purgeTracing", mux.MethodGet, purgeTracing)
+	hmux.AddRoute("/health", mux.MethodGet, healthCheck)
 }
 
 func StartServer() {

--- a/static/api/spec/target-api.json
+++ b/static/api/spec/target-api.json
@@ -182,7 +182,7 @@
             "in": "body",
             "required": true,
             "name": "traceData",
-            "description": "ceredential",
+            "description": "credential",
             "schema": {
               "type": "object",
               "properties": {
@@ -272,7 +272,7 @@
             "required": true,
             "type": "string",
             "name": "secret",
-            "description": "officer ceredential"
+            "description": "officer credential"
           }
         ],
         "responses": {
@@ -334,14 +334,14 @@
             "required": true,
             "type": "number",
             "name": "ageHour",
-            "description": "ceredential"
+            "description": "credential"
           },
           {
             "in": "query",
             "required": true,
             "type": "string",
             "name": "secret",
-            "description": "ceredential"
+            "description": "credential"
           }
         ],
         "responses": {

--- a/static/api/spec/target-api.json
+++ b/static/api/spec/target-api.json
@@ -21,18 +21,12 @@
       "description": "The endpoint that used by admin to upload, query and purge trace data"
     }
   ],
-  "schemes": [
-    "http","https"
-  ],
+  "schemes": ["http", "https"],
   "paths": {
     "/getHandshakePin": {
       "get": {
-        "tags": [
-          "User API"
-        ],
-        "produces": [
-          "application/json"
-        ],
+        "tags": ["User API"],
+        "produces": ["application/json"],
         "parameters": [
           {
             "in": "query",
@@ -49,11 +43,11 @@
               "type": "object",
               "properties": {
                 "status": {
-                  "type" : "string"
+                  "type": "string"
                 },
                 "pin": {
-                  "type" : "string",
-                  "description" : "The pin to be used to gain access the the blue tooth device running the tracing app"
+                  "type": "string",
+                  "description": "The pin to be used to gain access the the blue tooth device running the tracing app"
                 }
               }
             }
@@ -69,12 +63,8 @@
     },
     "/getTempIDs": {
       "get": {
-        "tags": [
-          "User API"
-        ],
-        "produces": [
-          "application/json"
-        ],
+        "tags": ["User API"],
+        "produces": ["application/json"],
         "parameters": [
           {
             "in": "query",
@@ -91,28 +81,28 @@
               "type": "object",
               "properties": {
                 "status": {
-                  "type" : "string"
+                  "type": "string"
                 },
                 "refreshTime": {
                   "type": "number",
-                  "description" : "Time stamp on which the blue tooth device to obtain another set of tempIDs"
+                  "description": "Time stamp on which the blue tooth device to obtain another set of tempIDs"
                 },
                 "tempIDs": {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
                     "properties": {
                       "tempID": {
-                        "type" : "string",
-                        "description" : "List of temporary ID to be used by blue tooth defice to be exchanged during contact"
+                        "type": "string",
+                        "description": "List of temporary ID to be used by blue tooth defice to be exchanged during contact"
                       },
                       "startTime": {
-                        "type" : "number",
-                        "description" : "UNIX time stamp on which this temporary ID is valid and used for exchange with other bluetooth device"
+                        "type": "number",
+                        "description": "UNIX time stamp on which this temporary ID is valid and used for exchange with other bluetooth device"
                       },
                       "expiryTime": {
-                        "type" : "number",
-                        "description" : "UNIX timestamp on which this temporary ID become expired and should not be used to exchange data with other bluetooth device"
+                        "type": "number",
+                        "description": "UNIX timestamp on which this temporary ID become expired and should not be used to exchange data with other bluetooth device"
                       }
                     }
                   }
@@ -129,14 +119,16 @@
         }
       }
     },
-    "/registerUid":{
+    "/health": {
       "get": {
-        "tags": [
-          "Officer API"
-        ],
-        "produces": [
-          "application/json"
-        ],
+        "tags": ["User API"],
+        "responses": { "204": { "description": "No Content" } }
+      }
+    },
+    "/registerUid": {
+      "get": {
+        "tags": ["Officer API"],
+        "produces": ["application/json"],
         "parameters": [
           {
             "in": "query",
@@ -144,13 +136,15 @@
             "type": "string",
             "name": "secret",
             "description": "Officer credential"
-          },{
+          },
+          {
             "in": "query",
             "required": true,
             "type": "string",
             "name": "uid",
             "description": "User Identification Number, a 21 digit string that can be used to identify the actual user. It should not contains personal information such as name, phone number, email, etc"
-          },{
+          },
+          {
             "in": "query",
             "required": true,
             "type": "string",
@@ -181,12 +175,8 @@
     },
     "/uploadData": {
       "post": {
-        "tags": [
-          "Officer API"
-        ],
-        "produces": [
-          "application/json"
-        ],
+        "tags": ["Officer API"],
+        "produces": ["application/json"],
         "parameters": [
           {
             "in": "body",
@@ -202,40 +192,40 @@
                 },
                 "uploadToken": {
                   "type": "string",
-                  "description" : "Securit token used to authorize this upload. The token can be obtained using getUploadToken endpoint using officials secret"
+                  "description": "Securit token used to authorize this upload. The token can be obtained using getUploadToken endpoint using officials secret"
                 },
                 "traces": {
-                  "description" : "The trace data to be uploaded",
+                  "description": "The trace data to be uploaded",
                   "type": "array",
                   "items": {
                     "properties": {
                       "timestamp": {
                         "type": "number",
-                        "description" : "Contact time stamp"
+                        "description": "Contact time stamp"
                       },
                       "msg": {
                         "type": "string",
-                        "description" : "Received TempID"
+                        "description": "Received TempID"
                       },
                       "modelC": {
                         "type": "string",
-                        "description" : "Device model name of the Central side"
+                        "description": "Device model name of the Central side"
                       },
                       "modelP": {
                         "type": "string",
-                        "description" : "Device model name of the Peripheral side"
+                        "description": "Device model name of the Peripheral side"
                       },
                       "rssi": {
                         "type": "number",
-                        "description" : "Bluetooth signal strength"
+                        "description": "Bluetooth signal strength"
                       },
                       "txPower": {
                         "type": "number",
-                        "description" : "Bluetooth transfer power"
+                        "description": "Bluetooth transfer power"
                       },
                       "org": {
                         "type": "string",
-                        "description" : "Organization of the counterpart device"
+                        "description": "Organization of the counterpart device"
                       }
                     }
                   }
@@ -267,12 +257,8 @@
     },
     "/getTracing": {
       "get": {
-        "tags": [
-          "Officer API"
-        ],
-        "produces": [
-          "application/json"
-        ],
+        "tags": ["Officer API"],
+        "produces": ["application/json"],
         "parameters": [
           {
             "in": "query",
@@ -340,12 +326,8 @@
     },
     "/purgeTracing": {
       "get": {
-        "tags": [
-          "Officer API"
-        ],
-        "produces": [
-          "application/json"
-        ],
+        "tags": ["Officer API"],
+        "produces": ["application/json"],
         "parameters": [
           {
             "in": "query",
@@ -369,7 +351,7 @@
               "type": "object",
               "properties": {
                 "status": {
-                  "type" : "string"
+                  "type": "string"
                 }
               }
             }
@@ -380,18 +362,13 @@
           "404": {
             "description": "token not found not found"
           }
-
         }
       }
     },
     "/getUploadToken": {
       "get": {
-        "tags": [
-          "Officer API"
-        ],
-        "produces": [
-          "application/json"
-        ],
+        "tags": ["Officer API"],
+        "produces": ["application/json"],
         "parameters": [
           {
             "in": "query",
@@ -415,10 +392,10 @@
               "type": "object",
               "properties": {
                 "status": {
-                  "type" : "string"
+                  "type": "string"
                 },
                 "token": {
-                  "type" : "string"
+                  "type": "string"
                 }
               }
             }
@@ -434,12 +411,8 @@
     },
     "/registerOid": {
       "get": {
-        "tags": [
-          "Admin API"
-        ],
-        "produces": [
-          "application/json"
-        ],
+        "tags": ["Admin API"],
+        "produces": ["application/json"],
         "parameters": [
           {
             "in": "query",
@@ -470,7 +443,7 @@
               "type": "object",
               "properties": {
                 "status": {
-                  "type" : "string"
+                  "type": "string"
                 }
               }
             }
@@ -486,12 +459,8 @@
     },
     "/deleteOid": {
       "get": {
-        "tags": [
-          "Admin API"
-        ],
-        "produces": [
-          "application/json"
-        ],
+        "tags": ["Admin API"],
+        "produces": ["application/json"],
         "parameters": [
           {
             "in": "query",
@@ -515,7 +484,7 @@
               "type": "object",
               "properties": {
                 "status": {
-                  "type" : "string"
+                  "type": "string"
                 }
               }
             }


### PR DESCRIPTION
This PR provides a simple `/health` endpoint for clients to determine HyperTrace server is alive and running.

## What feature/issue does this PR add
1. Added `/health` endpoint
2. Added `/health` to swagger documentation
3. Remove some lint warnings
4. Update README and Makefile for binary filename consistency

## How did you implement / how did you fix it
1.  Added `healthCheck` handler to return HTTP status code 204 (No Content)
2. Implemented warning suggestions
3. Changed Makefile `build` target binary name to `hypertrace.app`
4. Changed README instruction to execution filename

## How to test
1. `make build && hypertrace.app`
2. `curl -v localhost:8080/health`
5. Should see output below
```
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /health HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.82.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 204 No Content
< Cache-Control: no-cache
< Date: Wed, 06 Apr 2022 12:54:36 GMT
< 
* Connection #0 to host localhost left intact
```
